### PR TITLE
Instructios for Windows users

### DIFF
--- a/commands.bash
+++ b/commands.bash
@@ -44,36 +44,36 @@ mkdir -p $A_COMPOSER_CACHE
 ####
 
 function ane() {
-	docker run -it --rm -v $(pwd):/var/www/app -v $A_NPM_CACHE_MOUNT -v $A_NPM_CONFIG_MOUNT -v $A_SSH_NODE_MOUNT ambientum/node:6 "$@"
+	docker run -it --rm -v $A_APP_MOUNT -v $A_NPM_CACHE_MOUNT -v $A_NPM_CONFIG_MOUNT -v $A_SSH_NODE_MOUNT ambientum/node:6 "$@"
 }
 alias ane=ane
 
 function ape() {
-	docker run -it --rm -v $(pwd):/var/www/app -v $A_COMPOSER_MOUNT -v $A_SSH_PHP_MOUNT ambientum/php:7.0 "$@"
+	docker run -it --rm -v $A_APP_MOUNT -v $A_COMPOSER_MOUNT -v $A_SSH_PHP_MOUNT ambientum/php:7.0 "$@"
 }
 alias ape=ape
 
 # Node
 function node() {
-	docker run -it --rm -v $(pwd):/var/www/app -v $A_NPM_CACHE_MOUNT -v $A_NPM_CONFIG_MOUNT -v $A_SSH_NODE_MOUNT ambientum/node:6 node "$@"
+	docker run -it --rm -v $A_APP_MOUNT -v $A_NPM_CACHE_MOUNT -v $A_NPM_CONFIG_MOUNT -v $A_SSH_NODE_MOUNT ambientum/node:6 node "$@"
 }
 alias node=node
 
 # NPM
 function npm() {
-	docker run -it --rm -v $(pwd):/var/www/app -v $A_NPM_CACHE_MOUNT -v $A_NPM_CONFIG_MOUNT -v $A_SSH_NODE_MOUNT ambientum/node:6 npm "$@"
+	docker run -it --rm -v $A_APP_MOUNT -v $A_NPM_CACHE_MOUNT -v $A_NPM_CONFIG_MOUNT -v $A_SSH_NODE_MOUNT ambientum/node:6 npm "$@"
 }
 alias npm=npm
 
 # Gulp
 function gulp() {
-	docker run -it --rm -v $(pwd):/var/www/app -v $A_NPM_CACHE_MOUNT -v $A_SSH_NODE_MOUNT ambientum/gulp-cli:1.2 gulp "$@"
+	docker run -it --rm -v $A_APP_MOUNT -v $A_NPM_CACHE_MOUNT -v $A_SSH_NODE_MOUNT ambientum/gulp-cli:1.2 gulp "$@"
 }
 alias gulp=gulp
 
 # Vue
 function vue() {
-	docker run -it --rm -v $(pwd):/var/www/app -v $A_NPM_CACHE_MOUNT -v $A_SSH_NODE_MOUNT ambientum/vue-cli:2.2 vue "$@"
+	docker run -it --rm -v $A_APP_MOUNT -v $A_NPM_CACHE_MOUNT -v $A_SSH_NODE_MOUNT ambientum/vue-cli:2.2 vue "$@"
 }
 alias vue=vue
 
@@ -83,12 +83,12 @@ alias vue=vue
 
 # PHP
 function php() {
-	docker run -it --rm -v $(pwd):/var/www/app -v $A_COMPOSER_MOUNT -v $A_SSH_PHP_MOUNT ambientum/php:7.0 php "$@"
+	docker run -it --rm -v $A_APP_MOUNT -v $A_COMPOSER_MOUNT -v $A_SSH_PHP_MOUNT ambientum/php:7.0 php "$@"
 }
 alias php=php
 
 # Composer
 function composer() {
-	docker run -it --rm -v $(pwd):/var/www/app -v $A_COMPOSER_MOUNT -v $A_SSH_PHP_MOUNT ambientum/php:7.0 composer "$@"
+	docker run -it --rm -v $A_APP_MOUNT -v $A_COMPOSER_MOUNT -v $A_SSH_PHP_MOUNT ambientum/php:7.0 composer "$@"
 }
 alias composer=composer

--- a/commands.bash
+++ b/commands.bash
@@ -18,6 +18,9 @@ A_SSH_HOME=$HOME/.ssh
 #### YOU KNOW WHAT YOU'RE DOING           #
 ###########################################
 
+# For Windows users using Git Bash, add / at the beginning of the variables MOUNT
+# Example: A_APP_MOUNT=/$(pwd):/var/www/app
+
 # Mount for SSH Directories
 A_SSH_NODE_MOUNT=$A_SSH_HOME:/home/node-user/.ssh
 A_SSH_PHP_MOUNT=$A_SSH_HOME:/home/php-user/.ssh


### PR DESCRIPTION
Windows users must to add / at beginning of MOUNT variables to can run commands outside container.