### PR TITLE
Simple fix macos chown

### DIFF
--- a/commands.bash
+++ b/commands.bash
@@ -20,7 +20,7 @@ mkdir -p $A_COMPOSER
 ###########################################
 
 # reset permissions
-chown -R $(whoami):$(whoami) $A_BASE
+chown -R `id -u`:`id -g` $A_BASE
 
 # home directory
 A_USER_HOME=/home/ambientum


### PR DESCRIPTION
On OS X, the primary group is (in most cases): `staff`, unless you or your user directory manager changed it.

> chown -R $(whoami):$(whoami) $A_BASE  :x:

![macos-chown](https://user-images.githubusercontent.com/3202177/28682573-db4becc6-72d3-11e7-8bda-0d0cb76f9ada.png)

Instead of using `whoami`, it is possible to use the `id`:

> chown -R `id -u`:`id -g` $A_BASE  :tada: