### PR TITLE
Update linux alpine version to 3.8

### DIFF
--- a/php/7.1/Dockerfile
+++ b/php/7.1/Dockerfile
@@ -7,7 +7,7 @@
 # Strategy:      PHP From PHP-Alpine Repository (CODECASTS) (https://php-alpine.codecasts.rocks)
 # Base distro:   Alpine 3.7
 #
-FROM alpine:3.7
+FROM alpine:3.8
 
 # Repository/Image Maintainer
 LABEL maintainer="Diego Hernandes <diego@hernandev.com>"

--- a/php/7.2/Dockerfile
+++ b/php/7.2/Dockerfile
@@ -7,7 +7,7 @@
 # Strategy:      PHP From PHP-Alpine Repository (CODECASTS) (https://php-alpine.codecasts.rocks)
 # Base distro:   Alpine 3.7
 #
-FROM alpine:3.7
+FROM alpine:3.8
 
 # Repository/Image Maintainer
 LABEL maintainer="Diego Hernandes <diego@hernandev.com>"


### PR DESCRIPTION
I was set up an environment using ambientum with PHP and during the build I saw the following error:

ERROR: apk-tools-2.9.1-r2: package mentioned in index not found (try 'apk update')

After searched, I found the root of the problem, the alpine version. The current version 3.7 don't have access to some repositories. So, I updated the version to generate an image in my machine and it works!

Follow below some sources of my search:
* https://bugs.alpinelinux.org/issues/8965
* https://github.com/gliderlabs/docker-alpine/issues/350

I hope to help, thanks!